### PR TITLE
meta-nuvoton: update u-boot/kernel/loadsvf recipes and layer config

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,4 +7,4 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "nuvoton-layer"
 BBFILE_PATTERN_nuvoton-layer = ""
 LAYERVERSION_nuvoton-layer = "1"
-LAYERSERIES_COMPAT_nuvoton-layer = "warrior zeus dunfell"
+LAYERSERIES_COMPAT_nuvoton-layer = "dunfell gatesgarth hardknott"

--- a/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
+++ b/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 
 UBRANCH = "npcm7xx-v2019.01"
 SRC_URI = "git://github.com/Nuvoton-Israel/u-boot.git;branch=${UBRANCH}"
-SRCREV = "4deb40be58c0bf653bc4b59e4b9bdf8329ba070e"
+SRCREV = "8421c43d29043678a534766a922723514c27b302"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-nuvoton_git.bb
+++ b/recipes-kernel/linux/linux-nuvoton_git.bb
@@ -1,7 +1,7 @@
 KBRANCH ?= "Poleg-5.4-OpenBMC"
-LINUX_VERSION ?= "5.4.16"
+LINUX_VERSION ?= "5.4.80"
 
-SRCREV="317aef891ad9d3d054e8f8999be2897bf4b23505"
+SRCREV="df5ec3157d3b7369d2f1e1a4af38c2309460d7e3"
 
 require linux-nuvoton.inc
 SRC_URI_append_nuvoton = " file://0004-driver-ncsi-replace-del-timer-sync.patch"

--- a/recipes-nuvoton/loadsvf/loadsvf_git.bb
+++ b/recipes-nuvoton/loadsvf/loadsvf_git.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = "git://github.com/Nuvoton-Israel/loadsvf.git"
-SRCREV = "69d077629d5c85309c8dc17623d8586464db5c50"
+SRCREV = "118e1f0b23314e2d293b34dc1f6ae0242e0ea82a"
 S = "${WORKDIR}/git/"
 
 inherit autotools pkgconfig


### PR DESCRIPTION
- u-boot srcrev bump 9033cd58bf..8421c43d29
- kernel srcrev bump 6687842ee6..df5ec3157d
- loadsvf srcrev bump f2296005cb..118e1f0b23
- update yocto release name
- update kernel version to 5.4.80

Signed-off-by: George Hung <george.hung@quantatw.com>